### PR TITLE
Add comment specifing normalized echo values unless documented otherwise

### DIFF
--- a/marine_sensor_msgs/msg/RadarEcho.msg
+++ b/marine_sensor_msgs/msg/RadarEcho.msg
@@ -3,5 +3,9 @@
 # single ray.
 
 # Series of intensities from closest to farthest
-# along a given angle increment. [device-specific units]
+# along a given angle increment. For interoperability,
+# values should be normalized from 0.0 to 1.0.
+# Exceptions to using normalized values should be well
+# documented in the device driver and supporting software.
+# [device-specific units]
 float32[] echoes


### PR DESCRIPTION
A collaborator looking at the RadarEcho message recomended that echo values should be normalized. I mostly agree but want to keep the option open for radars that might have a good reason to report unnormalized values. A future RadarInfo type message could be used to report such a use.